### PR TITLE
Allows a substitution to contain an equals character

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "replace"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap 2.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "replace"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["zsiegel <zac@rw.co>"]
 
 [dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,7 +93,7 @@ fn main() {
 
             let mut values = HashMap::new();
             for replacement in &available_values {
-                let kv: Vec<&str> = replacement.split("=").collect();
+                let kv: Vec<&str> = replacement.splitn(2, "=").collect();
                 values.insert(kv[0], kv[1]);
             }
 


### PR DESCRIPTION
When you `split` the replacement values, what you really want is `splitn` so that if there are more than one `=` sign in that line, the rest of them are included in the replacement.

Use case: if your variable contains a url:
`FOO_BAR=db://user:pass@my_db:9999?ssl=true` with the current behavior, anything after `ssl` is cropped out.